### PR TITLE
Update Helpers.App.cs to have the module start and end item decorators for tag mechanic. 

### DIFF
--- a/CRM.Client/Helpers.App.cs
+++ b/CRM.Client/Helpers.App.cs
@@ -18,7 +18,8 @@ public static partial class Helpers
     {
         return true;
     }
-
+    
+    // {{ModuleItemStart:Tags}}
     public static List<DataObjects.Tag> AvailableTagListApp(DataObjects.TagModule? Module, List<Guid> ExcludeTags)
     {
         var output = new List<DataObjects.Tag>();
@@ -35,7 +36,8 @@ public static partial class Helpers
 
         return output;
     }
-
+    // {{ModuleItemEnd:Tags}}
+    
     private static List<string> GetDeletedRecordTypesApp()
     {
         var output = new List<string>();


### PR DESCRIPTION
After running the removal tool I had to manually fix these two files.  

<img width="1395" height="913" alt="image" src="https://github.com/user-attachments/assets/40979e17-4412-4169-b77c-029e69091eae" />

So I added an additional module item start for tags in the Helpers.App.cs so it can remove the tag related contents. 

There is also a bug where the CRM.Client\Shared\AppComponents\EditTag.App.razor isn't removed from the removal tool that could be looked at. For now it needs to be removed by hand. 