### PR TITLE
Minor sudologin and activator createinstance fix to stop exceptions

### DIFF
--- a/CRM.DataAccess/DataAccess.Users.cs
+++ b/CRM.DataAccess/DataAccess.Users.cs
@@ -1328,9 +1328,11 @@ public partial class DataAccess
                         } catch { }
 
                         try {
-                            var sl = decrypted["SudoLogin"];
-                            if (sl != null) {
-                                sudoLogin = (bool)sl;
+                            if (decrypted != null && decrypted.ContainsKey("SudoLogin")) {
+                                var sl = decrypted["SudoLogin"];
+                                if (sl != null) {
+                                    sudoLogin = (bool)sl;
+                                }
                             }
                         } catch { }
 
@@ -1379,9 +1381,11 @@ public partial class DataAccess
             } catch { }
 
             try {
-                var sl = decrypted["SudoLogin"];
-                if (sl != null) {
-                    sudoLogin = (bool)sl;
+                if(decrypted != null && decrypted.ContainsKey("SudoLogin")) {
+                    var sl = decrypted["SudoLogin"];
+                    if (sl != null) {
+                        sudoLogin = (bool)sl;
+                    }
                 }
             } catch { }
 

--- a/CRM.DataAccess/DataAccess.Utilities.cs
+++ b/CRM.DataAccess/DataAccess.Utilities.cs
@@ -1732,8 +1732,12 @@ public partial class DataAccess
 
             if (property.IsDefined(typeof(SensitiveAttribute))) {
                 object? defaultValue = null;
-                try {
-                    defaultValue = Activator.CreateInstance(propertyType);
+                try {                    
+                    if(propertyType == typeof(System.String)) {
+                        defaultValue = string.Empty;
+                    } else {
+                        defaultValue = Activator.CreateInstance(propertyType);
+                    }
                 } catch { }
 
                 // For specific item types return a value instead of null.


### PR DESCRIPTION
Added a few if statement checks to prevent exceptions being thrown in areas there is a try { } catch {} just throwing away an exception.  I noticed this area only gets hit when we run into a typeof string so I added a check explicitly checking for that and sets the default value to an empty string instead of null which seems more appropriate for an initialized string. 

<img width="981" height="480" alt="image" src="https://github.com/user-attachments/assets/345170ac-262c-455f-8a76-0528a8d9e9f4" />

I also noticed exceptions being thrown in a few of the DataAccess.User files where we are trying to access a dictionary that was actually null or missing a key.  I wrapped it with an if statement and it seems to have stopped the exceptions. 

<img width="973" height="604" alt="image" src="https://github.com/user-attachments/assets/fe7dbace-0fe4-4200-a8e2-c7837f56dde2" />


I'd like these fixes because recently I have been using the Diagnostic tools in visual studio to look for exceptions being thrown in the system.  If you double click on the exception it brings you to where in the code it happened and has a small snapshot of some of the data at the time.  Its pretty neat but was getting flooded with the exceptions being tossed and thrown away, as you can see in the screen shot below there are a few other places tossing exceptions that are being ignored but they only happen on bootup so aren't something I've been worrying about.

<img width="1368" height="759" alt="image" src="https://github.com/user-attachments/assets/e41d75c8-65e4-4aa5-9585-301bc60d36d2" />

Thanks!